### PR TITLE
Added publish to Azure Artifacts and Sonatype Nexus maven repos

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2020 Moesif, Inc
+Copyright (c) 2021 Moesif, Inc
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ without importing framework specific dependencies. Any Web Application built on 
 For SBT users, add dependency to your `build.sbt`:
 
 ```bash
-libraryDependencies += "com.moesif.filter" % "moesif-play-filter" % "1.1"
+libraryDependencies += "com.moesif.filter" % "moesif-play-filter" % "1.5"
 ```
 
 For Maven users, add dependency to your `pom.xml`:
@@ -28,26 +28,21 @@ For Maven users, add dependency to your `pom.xml`:
 <dependency>
     <groupId>com.moesif.filter</groupId>
     <artifactId>moesif-play-filter</artifactId>
-    <version>1.1</version>
+    <version>1.5</version>
 </dependency>
 ```
 
 For Gradle users, add the Moesif dependency to your project's build.gradle file:
 
 ```gradle
-// Include jcenter repository if you don't already have it.
-repositories {
-    jcenter()
-}
- 
 dependencies {   
-    compile 'com.moesif.filter:moesif-play-filter:1.1'
+    compile 'com.moesif.filter:moesif-play-filter:1.5'
 }
 ```
 
 #### Others
 
-The jars are available from a public [Bintray Jcenter](https://bintray.com/moesif/maven/moesif-servlet) repository.
+The jars are available from a public [repo.maven.apache.org - moesif-play-filter](https://repo.maven.apache.org/maven2/com/moesif/filter/moesif-play-filter/) repository.
 
 
 ## How to use

--- a/build.sbt
+++ b/build.sbt
@@ -2,8 +2,6 @@
 name := "moesif-play-filter"
 organization := "com.moesif.filter"
 
-version := "1.3"
-
 assemblyJarName in assembly := "moesif-play-filter-1.0.jar"
 
 assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false)
@@ -32,6 +30,7 @@ scmInfo := Some(
 )
 organizationName := "Moesif Inc"
 organizationHomepage := Some(url("http://www.moesif.com/"))
+homepage := Some(url("https://github.com/Moesif/moesif-play-filter"))
 developers += Developer("moesif", "Moesif API", "support@moesif.com", url("https://www.moesif.com"))
 crossPaths := false
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,2 @@
-sbt.version=1.2.1
+# sbt-sonatype requires at least sbt 1.3.1
+sbt.version=1.4.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0-M2")
-addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.7")

--- a/publish.sbt
+++ b/publish.sbt
@@ -1,0 +1,22 @@
+lazy val repoCredsRealm = sys.env.get("REPO_CREDS_REALM").getOrElse("Please set env var: REPO_CREDS_REALM")
+lazy val repoCredsHost = sys.env.get("REPO_CREDS_HOST").getOrElse("Please set env var: REPO_CREDS_HOST")
+lazy val repoCredsUser = sys.env.get("REPO_CREDS_USER").getOrElse("Please set env var: REPO_CREDS_USER")
+lazy val repoCredsPassword = sys.env.get("REPO_CREDS_PASSWORD").getOrElse("Please set env var: REPO_CREDS_PASSWORD")
+
+lazy val repoFriendlyName = sys.env.get("REPO_PUBLISH_FRIENDLY_NAME").getOrElse("Default publish friendly name")
+lazy val repoUrl = sys.env.get("REPO_PUBLISH_URL").getOrElse("Please set env var: REPO_PUBLISH_URL")
+
+// If we prefer to get credentials from a local file,
+//lazy val repoCredsFile = "myRepo.credentials"
+//credentials += Credentials(Path.userHome / ".sbt" / repoCredsFile)
+
+sonatypeProfileName := sys.env.get("SONATYPE_PROFILE_NAME").getOrElse("Please set env var: SONATYPE_PROFILE_NAME")
+credentials += Credentials(repoCredsRealm, repoCredsHost, repoCredsUser, repoCredsPassword)
+
+if (repoCredsHost.toLowerCase().contains("oss.sonatype.org".toLowerCase())) {
+    publishTo := sonatypePublishToBundle.value
+}
+else {
+    resolvers += repoFriendlyName at repoUrl
+    publishTo := Some(repoFriendlyName at repoUrl)
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,1 @@
+ThisBuild / version := "1.5"


### PR DESCRIPTION
Added ability to publish to maven repos:
* Nexus Sonatype maven (repo.maven.apache.org) 
* Azure Artifacts maven repo 
* Deploy to other repos such as JFrog should also work with other maven repos too - as all configs are via env vars.
* Also ensured PGP signing works
* Required upgrade of sbt version to support deploying to sonatype
* Moved version # to separate file
* v 1.5

Tested locally, but not yet on fully automated Azure Devops release pipeline. Can try after merging to master.