### PR TITLE
Log4j for CVE-2021-44228

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ without importing framework specific dependencies. Any Web Application built on 
 For SBT users, add dependency to your `build.sbt`:
 
 ```bash
-libraryDependencies += "com.moesif.filter" % "moesif-play-filter" % "1.5"
+libraryDependencies += "com.moesif.filter" % "moesif-play-filter" % "1.10"
 ```
 
 For Maven users, add dependency to your `pom.xml`:
@@ -28,7 +28,7 @@ For Maven users, add dependency to your `pom.xml`:
 <dependency>
     <groupId>com.moesif.filter</groupId>
     <artifactId>moesif-play-filter</artifactId>
-    <version>1.5</version>
+    <version>1.10</version>
 </dependency>
 ```
 
@@ -36,7 +36,7 @@ For Gradle users, add the Moesif dependency to your project's build.gradle file:
 
 ```gradle
 dependencies {   
-    compile 'com.moesif.filter:moesif-play-filter:1.5'
+    compile 'com.moesif.filter:moesif-play-filter:1.10'
 }
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,10 @@ libraryDependencies += "com.moesif.api" % "moesifapi" % "1.6.13"
 // https://mvnrepository.com/artifact/com.typesafe.play/play
 libraryDependencies += "com.typesafe.play" %% "play" % "2.6.23"
 
+// dont use log4j lower than 2.15 due to Log4j for CVE-2021-44228
+libraryDependencies += "org.apache.logging.log4j" % "log4j-core" % "2.15.0"
+libraryDependencies += "org.apache.logging.log4j" % "log4j-api" % "2.15.0"
+
 
 assemblyExcludedJars in assembly := {
   val cp = (fullClasspath in assembly).value

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "1.9"
+ThisBuild / version := "1.10"


### PR DESCRIPTION
Log4j for CVE-2021-44228
Bump version to 1.10