### PR TITLE
SDK Fix for low volume event buffering

### DIFF
--- a/src/main/scala/com/moesif/filter/MoesifApiFilter.scala
+++ b/src/main/scala/com/moesif/filter/MoesifApiFilter.scala
@@ -1,32 +1,26 @@
 package com.moesif.filter
 
-import java.util.Date
-
-import com.moesif.api.{Base64, MoesifAPIClient, BodyParser => MoesifBodyParser}
-import com.moesif.api.models.{EventBuilder, EventModel, EventRequestBuilder, EventResponseBuilder}
-import com.moesif.api.http.client.HttpContext
-import com.moesif.api.http.response.HttpResponse
-import com.moesif.api.http.client.APICallBack
-import com.moesif.api.models.AppConfigModel
-import java.util.logging._
-
-import play.api.Configuration
-import play.api.inject.{SimpleModule, bind}
-
-import java.util.concurrent.{Executors, ScheduledExecutorService, ScheduledFuture, TimeUnit}
-import scala.collection.JavaConverters._
-import javax.inject.{Inject, Singleton}
 import akka.stream.scaladsl.Flow
 import akka.stream.stage.{GraphStage, GraphStageLogic, InHandler, OutHandler}
 import akka.stream.{Attributes, FlowShape, Materializer}
 import akka.util.ByteString
 import com.moesif.api.controllers.APIController
+import com.moesif.api.http.client.{APICallBack, HttpContext}
+import com.moesif.api.http.response.HttpResponse
+import com.moesif.api.models._
+import com.moesif.api.{Base64, MoesifAPIClient, BodyParser => MoesifBodyParser}
 import org.joda.time.format.DateTimeFormat
 import org.joda.time.{DateTime, DateTimeZone}
+import play.api.Configuration
+import play.api.inject.{SimpleModule, bind}
 import play.api.libs.streams.Accumulator
 import play.api.mvc.{EssentialAction, EssentialFilter, RequestHeader, Result}
-import play.libs.Scala
 
+import java.util.Date
+import java.util.concurrent.{Executors, ScheduledExecutorService, ScheduledFuture, TimeUnit}
+import java.util.logging._
+import javax.inject.{Inject, Singleton}
+import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.util.{Failure, Random, Success, Try}
 /**

--- a/src/main/scala/com/moesif/filter/MoesifApiFilterConfig.scala
+++ b/src/main/scala/com/moesif/filter/MoesifApiFilterConfig.scala
@@ -9,9 +9,10 @@ import play.api.Configuration
   * @param moesifApplicationId Your Moesif Application Id can be found in the Moesif Portal. After signing up for a Moesif account, your Moesif Application Id
   *                            will be displayed during the onboarding steps. You can always find your Moesif Application Id at any time by logging
   *                            into the Moesif Portal, click on the top right menu, and then clicking Installation.
+  * @param maxBatchTime Int of the max time in milliseconds to buffer events before sending
   */
 case class MoesifApiFilterConfig(maxApiEventsToHoldInMemory: Int, moesifApplicationId: String, requestBodyProcessingEnabled: Boolean = true,
-                                 moesifCollectorEndpoint: String, samplingPercentage: Int)
+                                 moesifCollectorEndpoint: String, samplingPercentage: Int, maxBatchTime: Int = 5000 )
 object MoesifApiFilterConfig {
   def fromConfiguration(conf: Configuration): MoesifApiFilterConfig = {
     val config = conf.get[Configuration]("play.filters.moesifApiFilter")

--- a/src/main/scala/com/moesif/filter/MoesifApiFilterConfig.scala
+++ b/src/main/scala/com/moesif/filter/MoesifApiFilterConfig.scala
@@ -1,7 +1,8 @@
 package com.moesif.filter
 
-import javax.inject.{Inject, Provider, Singleton}
 import play.api.Configuration
+
+import javax.inject.{Inject, Provider, Singleton}
 
 /**
   * Configuration for the moesif api filter


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/180631809

Events are sent by the SDK when the event buffer reaches it's capacity; however, if event transmission is slow, then this can delay event sending indefinitely.  This adds a maximum wait duration for the buffered events, and in the event that events are sent more slowly than one event per maximum send window, they're not buffered and sent immediately.  If events are being sent more frequently, they're buffered until either the buffer reaches capacity or until the maxBatchTime duration of milliseconds has elapsed since the first event was added to the current buffer.