### PR TITLE
Log4j for CVE-2021-45105

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ without importing framework specific dependencies. Any Web Application built on 
 For SBT users, add dependency to your `build.sbt`:
 
 ```bash
-libraryDependencies += "com.moesif.filter" % "moesif-play-filter" % "1.11"
+libraryDependencies += "com.moesif.filter" % "moesif-play-filter" % "1.13.0"
 ```
 
 For Maven users, add dependency to your `pom.xml`:
@@ -28,7 +28,7 @@ For Maven users, add dependency to your `pom.xml`:
 <dependency>
     <groupId>com.moesif.filter</groupId>
     <artifactId>moesif-play-filter</artifactId>
-    <version>1.11</version>
+    <version>1.13.0</version>
 </dependency>
 ```
 
@@ -36,7 +36,7 @@ For Gradle users, add the Moesif dependency to your project's build.gradle file:
 
 ```gradle
 dependencies {   
-    compile 'com.moesif.filter:moesif-play-filter:1.11'
+    compile 'com.moesif.filter:moesif-play-filter:1.13.0'
 }
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -12,9 +12,9 @@ libraryDependencies += "com.moesif.api" % "moesifapi" % "1.6.13"
 // https://mvnrepository.com/artifact/com.typesafe.play/play
 libraryDependencies += "com.typesafe.play" %% "play" % "2.6.23"
 
-// dont use log4j lower than 2.16 due to Log4j for CVE-2021-45046
-libraryDependencies += "org.apache.logging.log4j" % "log4j-core" % "2.16.0"
-libraryDependencies += "org.apache.logging.log4j" % "log4j-api" % "2.16.0"
+// dont use log4j lower than 2.17 due to Log4j for CVE-2021-45105
+libraryDependencies += "org.apache.logging.log4j" % "log4j-core" % "2.17.0"
+libraryDependencies += "org.apache.logging.log4j" % "log4j-api" % "2.17.0"
 
 
 assemblyExcludedJars in assembly := {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "1.12.0"
+ThisBuild / version := "1.13.0"


### PR DESCRIPTION
Log4j for CVE-2021-45105
Refactor: Update README.md
Refactor: Bump version to 1.13.0