### PR TITLE
Drop events for non-retriable http status code response, use perf improved latest moesfiapi-java

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ assemblyJarName in assembly := "moesif-play-filter-1.0.jar"
 assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false)
 
 // https://mvnrepository.com/artifact/com.moesif.api/moesifapi
-libraryDependencies += "com.moesif.api" % "moesifapi" % "1.7.9"
+libraryDependencies += "com.moesif.api" % "moesifapi" % "1.8.5"
 
 // https://mvnrepository.com/artifact/com.typesafe.play/play
 libraryDependencies += "com.typesafe.play" %% "play" % "2.6.23"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "1.18.0"
+ThisBuild / version := "1.19.0"


### PR DESCRIPTION
* When sending events to collector fail, do not re-queue back events if the status code indicates it is non-retriable. (DEV-7493)
* Improve perf and use latest `moesifapi-java` with fix https://github.com/Moesif/moesifapi-java/pull/63
* Changed logger name to standard package based name.